### PR TITLE
Add tutorials page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,4 +8,5 @@ main:
     url: /events/
   - title: '<i class="fa fa-file-text"></i> Documentation'
     url: https://github.com/citation-file-format/citation-file-format/blob/master/README.md
-
+  - title: '<i class="fa fa-graduation-cap"></i> Tutorials'
+    url: /tutorials/

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -1,0 +1,3 @@
+---
+title: Citation File Format - Tutorials
+---

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -2,17 +2,30 @@
 title: Citation File Format - Tutorials
 ---
 
-# Validating `CITATION.cff` files
+## Validating `CITATION.cff` files
 
 The Citation File Format provides a [JSON Schema](https://json-schema.org/) file 
 ([`schema.json`](https://github.com/citation-file-format/citation-file-format/blob/main/schema.json))
 that `CITATION.cff` files can be validated against.
 
-## Docker
+### Docker
 
+If you use `docker`, you can validate your `CITATION.cff` file as follows.
 
+1. Build the docker container:
 
-## Python 3
+```bash
+docker build -t cffvalidator \
+https://raw.githubusercontent.com/sdruskat/simple-cff-validator-docker/1.0.0/Dockerfile
+```
+
+2. Run the container. Note that you have supply the absolute path to the local `CITATION.cff` file you want to validate with `-v`:
+
+```bash
+docker run --rm -v </absolute/path/to/your/CITATION.cff>:/cff/CITATION.cff cffvalidator
+```
+
+### Python 3
 
 The [Citation File Format README](https://github.com/citation-file-format/citation-file-format#validation-heavy_check_mark)
 describes how to validate `CITATION.cff` files in Python 3.

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -14,7 +14,7 @@ that `CITATION.cff` files can be validated against.
 
 ## Python 3
 
-The [*Validation* section of the Citation File Format README](https://github.com/citation-file-format/citation-file-format#validation-heavy_check_mark)
+The [Citation File Format README](https://github.com/citation-file-format/citation-file-format#validation-heavy_check_mark)
 describes how to validate `CITATION.cff` files in Python 3.
 
 If you want to avoid cloning the Citation File Format repository, as described there, you can also [download the Python script directly](https://github.com/citation-file-format/citation-file-format/blob/main/examples/validator.py). Note that you may still need to install the required Python packages.

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -19,7 +19,8 @@ https://raw.githubusercontent.com/sdruskat/cff-validator-docker/1.0.0/Dockerfile
 ```
 2. Run the container. Note that you have supply the absolute path to the local `CITATION.cff` file you want to validate with `-v`:
 ```bash
-docker run --rm -v </absolute/path/to/your/CITATION.cff>:/cff/CITATION.cff cffvalidator
+docker run --rm \
+-v </absolute/path/to/your/CITATION.cff>:/cff/CITATION.cff cffvalidator
 ```
 
 ### Python 3

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -1,3 +1,20 @@
 ---
 title: Citation File Format - Tutorials
 ---
+
+# Validating `CITATION.cff` files
+
+The Citation File Format provides a [JSON Schema](https://json-schema.org/) file 
+([`schema.json`](https://github.com/citation-file-format/citation-file-format/blob/main/schema.json))
+that `CITATION.cff` files can be validated against.
+
+## Docker
+
+
+
+## Python 3
+
+The [*Validation* section of the Citation File Format README](https://github.com/citation-file-format/citation-file-format#validation-heavy_check_mark)
+describes how to validate `CITATION.cff` files in Python.
+
+If you want to avoid cloning the Citation File Format repository, as described there, you can also [download the Python script directly](https://github.com/citation-file-format/citation-file-format/blob/main/examples/validator.py). Note that you may still need to install the required Python packages.

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -15,6 +15,6 @@ that `CITATION.cff` files can be validated against.
 ## Python 3
 
 The [*Validation* section of the Citation File Format README](https://github.com/citation-file-format/citation-file-format#validation-heavy_check_mark)
-describes how to validate `CITATION.cff` files in Python.
+describes how to validate `CITATION.cff` files in Python 3.
 
 If you want to avoid cloning the Citation File Format repository, as described there, you can also [download the Python script directly](https://github.com/citation-file-format/citation-file-format/blob/main/examples/validator.py). Note that you may still need to install the required Python packages.

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -13,14 +13,11 @@ that `CITATION.cff` files can be validated against.
 If you use `docker`, you can validate your `CITATION.cff` file as follows.
 
 1. Build the docker container:
-
 ```bash
 docker build -t cffvalidator \
-https://raw.githubusercontent.com/sdruskat/simple-cff-validator-docker/1.0.0/Dockerfile
+https://raw.githubusercontent.com/sdruskat/cff-validator-docker/1.0.0/Dockerfile
 ```
-
 2. Run the container. Note that you have supply the absolute path to the local `CITATION.cff` file you want to validate with `-v`:
-
 ```bash
 docker run --rm -v </absolute/path/to/your/CITATION.cff>:/cff/CITATION.cff cffvalidator
 ```


### PR DESCRIPTION
Adds a tutorials page with a tutorial for using `validator.py` to validate `CITATION.cff` files.

- Fixes #23
- Fixes #22

# Changes

- Add tutorial page
- Add new nav link
- Add tutorial for using `validator.py`

# Review instructions

- [ ] Check if everything works:
- Checkout repo and [build site locally](https://github.com/citation-file-format/citation-file-format.github.io/blob/add-local-dev-instructions/README.md#develop-and-build-locally).
- Make sure the navigation link is in the right place and works
- Check wording on the tutorials page
- Go through the tutorial to test if everything works as expected