### PR TITLE
Add instructions to develop locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ This repository holds the sources for <https://citation-file-format.github.io/>.
 
 The site is built with the [Jekyll](https://jekyllrb.com/) static site generator and the [Minimal Mistakes](https://mmistakes.github.io/minimal-mistakes/) theme.
 
-## Build locally, with `docker`
+## Develop and build locally
+
+In order for all links in your local clone to point to pages in your locally served version of the site,
+you need to temporarily change the value for `url` in the Jekyll config in [`_config.yml`](https://github.com/citation-file-format/citation-file-format.github.io/blob/main/_config.yml#L44) to `url: http://127.0.0.1:4000`. **Do not commit this change.** If you want to commit changes to the config, make sure you change it back to `url: https://citation-file-format.github.io` first!
+
+### Build locally, with `docker`
 
 If you have docker installed, just run
 
@@ -16,8 +21,7 @@ docker run --rm --volume="$PWD:/srv/jekyll" --env JEKYLL_ENV=development -p 4000
 
 then open your browser to [`http://localhost:4000`](http://localhost:4000).
 
-
-## Build locally, on your own system
+### Build locally, on your own system
 
 ```shell
 # Make sure Ruby version >2.5 is installed


### PR DESCRIPTION
This PR adds instructions for what to do to let links resolve to the locally served version of the page, based on the `url` value in `_config.yml`.

## Review instructions

- Look at the changes in README.md and make sure they are correct and clearly communicated.