### PR TITLE
Highlight cffinit and add nav item

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,3 +10,5 @@ main:
     url: https://github.com/citation-file-format/citation-file-format/blob/master/README.md
   - title: '<i class="fa fa-graduation-cap"></i> Tutorials'
     url: /tutorials/
+  - title: '<i class="fa fa-plus-circle"></i> Create CFF file'
+    url: ./#create-a-citationcff-file-now

--- a/index.md
+++ b/index.md
@@ -70,10 +70,10 @@ that they can use when they cite your software in their work!
 
 # Create a `CITATION.cff` file now!
 
-You can start by copy-and-pasting the [example above](#what-is-a-citation-cff-file) into the root of your code repository, and adapt the information to your software.
+There are different options for getting started with the Citation File Format:
 
-You can also use a simple website to fill in the citation information for your software.
-To do so, go to the [`cffinit` website](https://citation-file-format.github.io/cff-initializer-javascript/).
+- Create a `CITATION.cff` file with ease using the form on the [cffinit website](https://citation-file-format.github.io/cff-initializer-javascript/){: .btn .btn--info}.
+- Copy and paste the [example above](#what-is-a-citation-cff-file) into the root of your code repository, and adapt the information to your software.
 
 To learn more about how to work with the Citation File Format, have a look at the [documentation](https://github.com/citation-file-format/citation-file-format/blob/main/README.md).
 


### PR DESCRIPTION
Adds a new navigation item "Create CFF file" (see first screenshot below) which link to the *Create a CITATION.cff file now!* section of the same page.

Also slightly restructures the above-mentioned section to include a bulleted list where the cffinit link is first, and adds a button with a link to cffinit for further highlighting (see second screenshot below).

![image](https://user-images.githubusercontent.com/3007126/140313996-bb12a66f-6f84-4b47-99b5-3fc00815515f.png)

![image](https://user-images.githubusercontent.com/3007126/140314051-42be4ee5-3077-49c5-abea-d69448d4d679.png)

# Review instructions
- [ ] Clone/update and build the repository:
```bash
bundle exec install
bundle exec jekyll serve -w
```
- [ ] Read text and play around with cffinit button and new nav item

