### PR TITLE
Fix outdated references to master branch

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -7,6 +7,6 @@ main:
   - title: '<i class="fa fa-handshake-o"></i> Events'
     url: /events/
   - title: '<i class="fa fa-file-text"></i> Documentation'
-    url: https://github.com/citation-file-format/citation-file-format/blob/master/README.md
+    url: https://github.com/citation-file-format/citation-file-format/blob/main/README.md
   - title: '<i class="fa fa-graduation-cap"></i> Tutorials'
     url: /tutorials/

--- a/about.md
+++ b/about.md
@@ -76,7 +76,7 @@ Older versions for CFF are listed in the following table.
 ## Contributing
 
 Contributions to CFF are welcome! Please have a look at the 
-[guidelines for contributing](https://github.com/citation-file-format/citation-file-format/blob/master/CONTRIBUTING.md).
+[guidelines for contributing](https://github.com/citation-file-format/citation-file-format/blob/main/CONTRIBUTING.md).
 
 # References
 

--- a/index.md
+++ b/index.md
@@ -99,7 +99,7 @@ The documentation has a brief [overview of available tools](https://github.com/c
 We try to make contributing to CFF as easy as possible! Even tweeting a problem may be helpful, it's *that* easy.
 
 Better still, if you can think of something that would make `CITATION.cff` files better, or you have found something that didn't work as you would have expected:
-Please check out how you can share your idea or bug report in the [contribution guide on GitHub](https://github.com/citation-file-format/citation-file-format/blob/master/CONTRIBUTING.md).
+Please check out how you can share your idea or bug report in the [contribution guide on GitHub](https://github.com/citation-file-format/citation-file-format/blob/main/CONTRIBUTING.md).
 
 {% capture acknowledgments %}
 #### Acknowledgments


### PR DESCRIPTION
Fixes some links to the `master` branch that has been renamed to `main`.