### PR TITLE
Edit example to identifiers: type: doi instead of doi:

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,7 +19,9 @@ authors:
     orcid: https://orcid.org/1234-5678-9101-1121
 title: "My Research Software"
 version: 2.0.4
-doi: 10.5281/zenodo.1234
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.1234
 date-released: 2021-08-11
 {% endhighlight %}
 


### PR DESCRIPTION
The `doi:` field in this example causes a warning in the cff-initializer-javascript tool.

> Property 'doi' was not identified as a basic field, so it was passed as an extra cff field.

Probably you want the given example to be parse(able) without warning(?)

Following from discussion in
* citation-file-format/cff-initializer-javascript#849